### PR TITLE
handle _sum reduce, tests are in sg view_api_test.go

### DIFF
--- a/views.go
+++ b/views.go
@@ -122,6 +122,15 @@ func ReduceViewResult(reduceFunction string, result *ViewResult) error {
 	case "_count":
 		result.Rows = []*ViewRow{{Value: float64(len(result.Rows))}}
 		return nil
+	case "_sum":
+		total := float64(0)
+		for _, row := range result.Rows {
+			// This could theoretically know how to unwrap our [channels, value]
+			// design_doc emit wrapper, but even so reduce would remain admin only.
+			total += collationToFloat64(row.Value)
+		}
+		result.Rows = []*ViewRow{{Value: total}}
+		return nil
 	default:
 		// TODO: Implement other reduce functions!
 		return fmt.Errorf("Sgbucket only supports _count reduce function")


### PR DESCRIPTION
This is an in-memory handler for `_sum`, comparable to the `_count` handler. I think it is safe to merge although I can't really test it until another API layer feature enables access to it. That's on it's way in a patch to Sync Gateway.

I hope we can review and merge this so it's ready when the other patch makes it. How is my float handling?