### PR TITLE
Expose Refresh() method to support lost TAP feed recovery

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -42,6 +42,7 @@ type Bucket interface {
 	View(ddoc, name string, params map[string]interface{}) (ViewResult, error)
 	ViewCustom(ddoc, name string, params map[string]interface{}, vres interface{}) error
 	StartTapFeed(args TapArguments) (TapFeed, error)
+	Refresh() error
 	Close()
 	Dump()
 	VBHash(docID string) uint32


### PR DESCRIPTION
Partially fixes https://github.com/couchbase/sync_gateway/issues/1710