### PR TITLE
Handle case where walrus bucket returns []float64 instead of []interface{}

### DIFF
--- a/collate.go
+++ b/collate.go
@@ -12,6 +12,7 @@ package sgbucket
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"

--- a/collate.go
+++ b/collate.go
@@ -56,8 +56,15 @@ func (c *JSONCollator) Collate(key1, key2 interface{}) int {
 	case kString:
 		return c.compareStrings(key1.(string), key2.(string))
 	case kArray:
-		array1 := key1.([]interface{})
-		array2 := key2.([]interface{})
+		// Handle the case where a walrus bucket is returning a []float64
+		array1, ok1 := key1.([]interface{})
+		if !ok1 {
+			array1 = ToArrayOfInterface(key1.([]float64))
+		}
+		array2, ok2 := key2.([]interface{})
+		if !ok2 {
+			array2 = ToArrayOfInterface(key2.([]float64))
+		}
 		for i, item1 := range array1 {
 			if i >= len(array2) {
 				return 1
@@ -87,7 +94,7 @@ func collationType(value interface{}) token {
 		return kNumber
 	case string:
 		return kString
-	case []interface{}:
+	case []interface{}, []float64:
 		return kArray
 	case map[string]interface{}:
 		return kObject
@@ -140,4 +147,12 @@ func compareFloats(n1, n2 float64) int {
 		return 1
 	}
 	return 0
+}
+
+func ToArrayOfInterface(arrayOfFloat64 []float64) []interface{} {
+	arrayOfInterface := make([]interface{}, len(arrayOfFloat64))
+	for i, v := range arrayOfFloat64 {
+		arrayOfInterface[i] = v
+	}
+	return arrayOfInterface
 }

--- a/collate.go
+++ b/collate.go
@@ -89,7 +89,7 @@ func collationType(value interface{}) token {
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
 	case reflect.Bool:
-		if !value {
+		if !v.Bool() {
 			return kFalse
 		}
 		return kTrue
@@ -161,8 +161,9 @@ func toSliceOfInterface(slice interface{}) []interface{} {
 	case reflect.Slice:
 		ret := make([]interface{}, s.Len())
 
-		for i, v := range s {
-			ret[i] = v.Interface()
+		//Can't range over s
+		for i := 0; i < s.Len(); i++ {
+			ret[i] = s.Index(i).Interface()
 		}
 
 		return ret


### PR DESCRIPTION
Needed to support upgrade to latest otto in sync_gateway this is part of the fix for https://github.com/couchbase/sync_gateway/issues/2471