### PR TITLE
Adds support for view 'keys' parameter

### DIFF
--- a/views.go
+++ b/views.go
@@ -73,6 +73,19 @@ func ProcessViewResult(result ViewResult, params map[string]interface{},
 
 	var collator JSONCollator
 
+	if keys, ok := params["keys"].([]interface{}); ok {
+		filteredRows := make(ViewRows, 0)
+		for _, targetKey := range keys {
+			i := sort.Search(len(result.Rows), func(i int) bool {
+				return collator.Collate(result.Rows[i].Key, targetKey) >= 0
+			})
+			if collator.Collate(result.Rows[i].Key, targetKey) == 0 {
+				filteredRows = append(filteredRows, result.Rows[i])
+			}
+		}
+		result.Rows = filteredRows
+	}
+
 	if startkey != nil {
 		i := sort.Search(len(result.Rows), func(i int) bool {
 			return collator.Collate(result.Rows[i].Key, startkey) >= 0

--- a/views.go
+++ b/views.go
@@ -79,7 +79,7 @@ func ProcessViewResult(result ViewResult, params map[string]interface{},
 			i := sort.Search(len(result.Rows), func(i int) bool {
 				return collator.Collate(result.Rows[i].Key, targetKey) >= 0
 			})
-			if collator.Collate(result.Rows[i].Key, targetKey) == 0 {
+			if i < len(result.Rows) && collator.Collate(result.Rows[i].Key, targetKey) == 0 {
 				filteredRows = append(filteredRows, result.Rows[i])
 			}
 		}


### PR DESCRIPTION
Adds support for 'keys' to the sg-bucket view post-processing (ProcessViewResult).  Aligns with Couchbase Server parameter, needed for https://github.com/couchbase/sync_gateway/issues/3823