### PR TITLE
Remove BucketNotifyFn

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -15,11 +15,6 @@ import (
 	"fmt"
 )
 
-// NOTE: not a tap event notification callback
-// When go-couchbase detects that the tap/dcp feed has been disconnected, will call this back.
-// TODO: rename to FeedStateNotify?
-type BucketNotifyFn func(bucket string, err error)
-
 // Raw representation of a bucket document - document body and xattr as bytes, along with cas.
 type BucketDocument struct {
 	Body   []byte

--- a/tap.go
+++ b/tap.go
@@ -40,12 +40,11 @@ type MutationFeed interface {
 
 // Parameters for requesting a TAP feed. Call DefaultTapArguments to get a default one.
 type FeedArguments struct {
-	ID         string         // Feed ID, used to build unique identifier for DCP feed
-	Backfill   uint64         // Timestamp of oldest item to send. Use TapNoBackfill to suppress all past items.
-	Dump       bool           // If set, server will disconnect after sending existing items.
-	KeysOnly   bool           // If true, client doesn't want values so server shouldn't send them.
-	Notify     BucketNotifyFn // Callback function to send notifications about lost Tap Feed
-	Terminator chan bool      // Feed will be terminated when this channel is closed (DCP Only)
+	ID         string    // Feed ID, used to build unique identifier for DCP feed
+	Backfill   uint64    // Timestamp of oldest item to send. Use TapNoBackfill to suppress all past items.
+	Dump       bool      // If set, server will disconnect after sending existing items.
+	KeysOnly   bool      // If true, client doesn't want values so server shouldn't send them.
+	Terminator chan bool // Feed will be terminated when this channel is closed (DCP Only)
 }
 
 // Value for TapArguments.Backfill denoting that no past events at all should be sent.  FeedNoBackfill value


### PR DESCRIPTION
Previously used for tap feed handling, no longer used for DCP.

Unused references removed from SG in https://github.com/couchbase/sync_gateway/pull/4247