### PR TITLE
Remove WriteUpdate from bucket interface

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -58,7 +58,6 @@ type KVStore interface {
 	Delete(k string) error
 	Remove(k string, cas uint64) (casOut uint64, err error)
 	Update(k string, exp uint32, callback UpdateFunc) (casOut uint64, err error)
-	WriteUpdate(k string, exp uint32, callback WriteUpdateFunc) (casOut uint64, err error)
 	Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 	StartDCPFeed(args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
 	StartTapFeed(args FeedArguments, dbStats *expvar.Map) (MutationFeed, error)


### PR DESCRIPTION
WriteUpdate is legacy from go-couchbase's integration.  Update serves the same purpose today, and WriteOpts aren't being used.