### PR TITLE
CBG-1763: Added Group ID field to FeedArguments

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -56,6 +56,7 @@ type FeedArguments struct {
 	KeysOnly   bool          // If true, client doesn't want values so server shouldn't send them.
 	Terminator chan bool     // Feed will be terminated when this channel is closed (DCP Only)
 	DoneChan   chan struct{} // DoneChan is closed when the mutation feed terminates.
+	GroupID	   string        // Config group ID the Sync Gateway instance is running with
 }
 
 // Value for TapArguments.Backfill denoting that no past events at all should be sent.  FeedNoBackfill value

--- a/tap.go
+++ b/tap.go
@@ -57,7 +57,6 @@ type FeedArguments struct {
 	Terminator       chan bool     // Feed will be terminated when this channel is closed (DCP Only)
 	DoneChan         chan struct{} // DoneChan is closed when the mutation feed terminates.
 	CheckpointPrefix string        // DCP checkpoint key prefix
-	SGCfgPrefix      string        // SG config key prefix
 }
 
 // Value for TapArguments.Backfill denoting that no past events at all should be sent.  FeedNoBackfill value

--- a/tap.go
+++ b/tap.go
@@ -50,13 +50,14 @@ type MutationFeed interface {
 
 // Parameters for requesting a TAP feed. Call DefaultTapArguments to get a default one.
 type FeedArguments struct {
-	ID         string        // Feed ID, used to build unique identifier for DCP feed
-	Backfill   uint64        // Timestamp of oldest item to send. Use TapNoBackfill to suppress all past items.
-	Dump       bool          // If set, server will disconnect after sending existing items.
-	KeysOnly   bool          // If true, client doesn't want values so server shouldn't send them.
-	Terminator chan bool     // Feed will be terminated when this channel is closed (DCP Only)
-	DoneChan   chan struct{} // DoneChan is closed when the mutation feed terminates.
-	GroupID	   string        // Config group ID the Sync Gateway instance is running with
+	ID               string        // Feed ID, used to build unique identifier for DCP feed
+	Backfill         uint64        // Timestamp of oldest item to send. Use TapNoBackfill to suppress all past items.
+	Dump             bool          // If set, server will disconnect after sending existing items.
+	KeysOnly         bool          // If true, client doesn't want values so server shouldn't send them.
+	Terminator       chan bool     // Feed will be terminated when this channel is closed (DCP Only)
+	DoneChan         chan struct{} // DoneChan is closed when the mutation feed terminates.
+	CheckpointPrefix string        // DCP checkpoint key prefix
+	SGCfgPrefix      string        // SG config key prefix
 }
 
 // Value for TapArguments.Backfill denoting that no past events at all should be sent.  FeedNoBackfill value


### PR DESCRIPTION
[CBG-1763](https://issues.couchbase.com/browse/CBG-1763)

Added a Group ID field to the `FeedArguments` struct, which will be filled on Sync Gateway so the DCP feed code can use it.

