### PR TITLE
CBG-2233 remove unused channel

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -58,7 +58,6 @@ type FeedArguments struct {
 	DoneChan         chan struct{}       // DoneChan is closed when the mutation feed terminates.
 	CheckpointPrefix string              // DCP checkpoint key prefix
 	Scopes           map[string][]string // Collection names to stream - map keys are scopes
-	Started          chan error          // If set, will return an error or nil when DCPClient started.
 }
 
 // Value for TapArguments.Backfill denoting that no past events at all should be sent.  FeedNoBackfill value


### PR DESCRIPTION
Revert "CBG-1143 add started channel for notification when DCP is ready (#76)"

This reverts commit 29ae27b3d9d06086e2a04a9a8bc9319e7b693f45.