### PR TITLE
Revert "CBG-2344: Add FeedOpExpiration"

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -25,7 +25,6 @@ const (
 	FeedOpDeletion
 	FeedOpCheckpointStart
 	FeedOpCheckpointEnd
-	FeedOpExpiration
 )
 
 // A TAP notification of an operation on the server.


### PR DESCRIPTION
Reverts couchbase/sg-bucket#79, as it's no longer necessary in the corresponding SG PR (https://github.com/couchbase/sync_gateway/pull/5719)