### PR TITLE
Narrow DataStore interface and add BucketStore

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -70,6 +70,7 @@ type TypedErrorStore interface {
 // A Couchbase Server collection within a bucket is an example of a DataStore.
 // The expiry field (exp) can take offsets or UNIX Epoch times.  See https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/doc-expiration.html
 type DataStore interface {
+	GetName() string // GetName returns the datastore name (usually a qualified collection name)
 	KVStore
 	XattrStore
 	SubdocStore
@@ -227,11 +228,14 @@ type WriteUpdateFunc func(current []byte) (updated []byte, opt WriteOptions, exp
 
 // Callback used by WriteUpdateWithXattr, used to transform the doc in preparation for update
 // Input parameters:
-//  doc, xattr, cas		existing doc body, xattr body, cas
+//
+//	doc, xattr, cas		existing doc body, xattr body, cas
+//
 // Return values:
-//  updatedDoc, updatedXattr	Mutated doc body, xattr body.  Return a nil value to indicate that no update should be performed.
-//  deletedDoc			Flag to indicate that the document body should be deleted
-//  err                         When error is returned, all updates are canceled
+//
+//	updatedDoc, updatedXattr	Mutated doc body, xattr body.  Return a nil value to indicate that no update should be performed.
+//	deletedDoc			Flag to indicate that the document body should be deleted
+//	err                         When error is returned, all updates are canceled
 type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error)
 
 // Cloned from go-couchbase, modified for use without a live bucket instance (takes the number of vbuckets as a parameter)

--- a/bucket.go
+++ b/bucket.go
@@ -41,9 +41,7 @@ const (
 	KeyNotFoundError = DataStoreErrorType(iota)
 )
 
-// A DataStore is a key-value store with a map/reduce query interface, as found in Couchbase Server 2.
-// The expiry field (exp) can take offsets or UNIX Epoch times.  See https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/doc-expiration.html
-type DataStore interface {
+type BucketStore interface {
 	GetName() string
 	UUID() (string, error)
 	Close()
@@ -51,6 +49,13 @@ type DataStore interface {
 	XattrStore
 	KVStore
 	ViewStore
+}
+
+// A DataStore is a basic key-value store with extended attributes.
+// The expiry field (exp) can take offsets or UNIX Epoch times.  See https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/doc-expiration.html
+type DataStore interface {
+	XattrStore
+	KVStore
 }
 
 // UpsertOptions are the options to use with the set operations

--- a/bucket.go
+++ b/bucket.go
@@ -14,9 +14,13 @@ import (
 	"fmt"
 )
 
+// DataStoreName provides the methods that can give you each part of a data store.
+//
+// Each implementation is free to decide how to store the data store name, to avoid both sgbucket leaking into implementations,
+// and also reduce duplication for storing these values, in the event SDKs already hold copies of names internally.
 type DataStoreName interface {
-	Scope() string
-	Collection() string
+	ScopeName() string
+	CollectionName() string
 }
 
 // Raw representation of a bucket document - document body and xattr as bytes, along with cas.
@@ -82,7 +86,6 @@ type TypedErrorStore interface {
 // A Couchbase Server collection within a bucket is an example of a DataStore.
 // The expiry field (exp) can take offsets or UNIX Epoch times.  See https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/doc-expiration.html
 type DataStore interface {
-	DataStoreName() DataStoreName
 	GetName() string // GetName returns the datastore name (usually a qualified collection name)
 	KVStore
 	XattrStore

--- a/bucket.go
+++ b/bucket.go
@@ -14,26 +14,9 @@ import (
 	"fmt"
 )
 
-type DataStoreName struct {
-	scope      string
-	collection string
-}
-
-// NewDataStoreName returns a DataStoreName for a given scope and collection.
-func NewDataStoreName(scope, collection string) DataStoreName {
-	return DataStoreName{scope, collection}
-}
-
-func (dsn *DataStoreName) String() string {
-	return dsn.scope + "." + dsn.collection
-}
-
-func (dsn *DataStoreName) Scope() string {
-	return dsn.scope
-}
-
-func (dsn *DataStoreName) Collection() string {
-	return dsn.collection
+type DataStoreName interface {
+	Scope() string
+	Collection() string
 }
 
 // Raw representation of a bucket document - document body and xattr as bytes, along with cas.

--- a/bucket.go
+++ b/bucket.go
@@ -242,14 +242,11 @@ type WriteUpdateFunc func(current []byte) (updated []byte, opt WriteOptions, exp
 
 // Callback used by WriteUpdateWithXattr, used to transform the doc in preparation for update
 // Input parameters:
-//
-//	doc, xattr, cas		existing doc body, xattr body, cas
-//
+//  doc, xattr, cas		existing doc body, xattr body, cas
 // Return values:
-//
-//	updatedDoc, updatedXattr	Mutated doc body, xattr body.  Return a nil value to indicate that no update should be performed.
-//	deletedDoc			Flag to indicate that the document body should be deleted
-//	err                         When error is returned, all updates are canceled
+//  updatedDoc, updatedXattr	Mutated doc body, xattr body.  Return a nil value to indicate that no update should be performed.
+//  deletedDoc			Flag to indicate that the document body should be deleted
+//  err                         When error is returned, all updates are canceled
 type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error)
 
 // Cloned from go-couchbase, modified for use without a live bucket instance (takes the number of vbuckets as a parameter)

--- a/bucket.go
+++ b/bucket.go
@@ -133,6 +133,7 @@ type KVStore interface {
 	Update(k string, exp uint32, callback UpdateFunc) (casOut uint64, err error)
 	Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 	GetExpiry(k string) (expiry uint32, err error)
+	Exists(k string) (exists bool, err error)
 }
 
 // SubdocStore describes methods that can be used to operate on parts of a document with a subdoc operation.

--- a/bucket.go
+++ b/bucket.go
@@ -41,6 +41,8 @@ const (
 	KeyNotFoundError = DataStoreErrorType(iota)
 )
 
+// BucketStore is a basic interface that describes a key-value/xattrs, with map-reduce view based data store.
+// Walrus and Couchbase Server buckets are two primary examples of data stores that implement this interface.
 type BucketStore interface {
 	GetName() string
 	UUID() (string, error)
@@ -52,6 +54,7 @@ type BucketStore interface {
 }
 
 // A DataStore is a basic key-value store with extended attributes.
+// A Couchbase Server collection within a bucket is an example of a DataStore.
 // The expiry field (exp) can take offsets or UNIX Epoch times.  See https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/doc-expiration.html
 type DataStore interface {
 	XattrStore


### PR DESCRIPTION
- `BucketStore` now describes something that can return one or more DataStores (i.e. Collections) and has bucket-level operations (`MutationFeedStore`, `BucketStoreFeature` capabilities)
- `DataStore` describes a basic data store that supports KV/Xattr/Subdoc
- Smaller interfaces for `KVStore` and `SubDocStore` that individual DataStores can implement
- `BucketStore` implementations can also implement `DynamicDataStoreBucket` which describes methods for creating and removing DataStores within a bucket (useful for testing purposes)