### PR TITLE
CBG-2276: Avoid channel allocation if no timeout is used

### DIFF
--- a/js_runner.go
+++ b/js_runner.go
@@ -191,9 +191,10 @@ func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
 			}
 		}
 
-		completed := make(chan bool)
+		var completed chan struct{}
 		timeout := runner.timeout
 		if timeout > 0 {
+			completed = make(chan struct{})
 			defer func() {
 				if caught := recover(); caught != nil {
 					if caught == ErrJSTimeout {
@@ -221,7 +222,9 @@ func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
 		}
 
 		result, err = runner.fn.Call(runner.fn, inputJS...)
-		close(completed)
+		if completed != nil {
+			close(completed)
+		}
 	}
 	if runner.After != nil {
 		return runner.After(result, err)


### PR DESCRIPTION
CBG-2276

A small optimisation for when running without a timeout set.

Leaving timeout logic in, but opting out of it on the SG side in https://github.com/couchbase/sync_gateway/pull/6004 for sync, import and conflict resolver functions (some of Jens' graphql work uses this JS timeout functionality)