### PR TITLE
CBG-2671 update to go.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: WillAbides/setup-go-faster@v1.8.0
         with:
           go-version: 1.19.5
       - uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/setup-go@v3
+      - uses: WillAbides/setup-go-faster@v1.8.0
         with:
           go-version: 1.19.5
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,34 @@ jobs:
         uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.5
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49.0
+
+  test-race:
+    runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/couchbaselabs
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.5
+      - uses: actions/checkout@v3
+      - name: Run Tests
+        run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        shell: bash
+      - name: Annotate Failures
+        if: always()
+        uses: guyarb/golang-test-annotations@v0.6.0
+        with:
+          test-results: test.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
     steps:
       - name: Setup Go Faster
-        uses: WillAbides/setup-go-faster@v1.7.0
+        uses: WillAbides/setup-go-faster@v1.8.0
         with:
-          go-version: ^1.17.5 # >=1.17.5, <2.0.0
+          go-version: ^1.19.5 # >=1.17.5, <2.0.0
       - uses: actions/checkout@v2
       - name: Build
         run: go build -v "./..."
@@ -34,6 +34,6 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.5.1
+        uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,90 @@
+# Copyright 2020-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+# config file for golangci-lint
+
+linters:
+  enable:
+    #- bodyclose # checks whether HTTP response body is closed successfully
+    #- dupl # Tool for code clone detection
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
+    #- goconst # Finds repeated strings that could be replaced by a constant
+    #- gocritic # The most opinionated Go source code linter
+    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
+    #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
+    #- gosec # (gas) Inspects source code for security problems
+    #- gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
+    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    #- ineffassign # Detects when assignments to existing variables are not used
+    #- nakedret # Finds naked returns in functions greater than a specified function length
+    #- prealloc # Finds slice declarations that could potentially be preallocated
+    #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    #- staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    #- structcheck # Finds unused struct fields - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    #- unconvert # Remove unnecessary type conversions
+    #- unparam # Reports unused function parameters
+    #- unused # (megacheck) Checks Go code for unused constants, variables, functions and types
+  disable:
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
+    - funlen # Tool for detection of long functions
+    - gochecknoglobals # Checks that no globals are present in Go code
+    - gochecknoinits # Checks that no init functions are present in Go code
+    - gocognit # Computes and checks the cognitive complexity of functions
+    - gocyclo # Computes and checks the cyclomatic complexity of functions
+    - godot # Check if comments end in a period
+    - godox # Tool for detection of FIXME, TODO and other comment keywords
+    - goerr113 # Golang linter to check the errors handling expressions
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - gomnd # An analyzer to detect magic numbers.
+    - gomodguard # Allow and block list linter for direct Go module dependencies.
+    - interfacer # Linter that suggests narrower interface types
+    - lll # Reports long lines
+    - misspell # Finds commonly misspelled English words in comments
+    - nestif # Reports deeply nested if statements
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - scopelint # Scopelint checks for unpinned variables in go programs
+    - stylecheck # Stylecheck is a replacement for golint
+    - testpackage # linter that makes you use a separate _test package
+    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
+    - whitespace # Tool for detection of leading and trailing whitespace
+    - wsl # Whitespace Linter - Forces you to use empty lines!
+    # Once fixed, should enable
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - deadcode # Finds unused code
+    - dupl # Tool for code clone detection
+    - goconst # Finds repeated strings that could be replaced by a constant
+    - gocritic # The most opinionated Go source code linter
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
+    - gosec # (gas) Inspects source code for security problems
+    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
+    - ineffassign # Detects when assignments to existing variables are not used
+    - nakedret # Finds naked returns in functions greater than a specified function length
+    - prealloc # Finds slice declarations that could potentially be preallocated
+    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - structcheck # Finds unused struct fields
+    - unconvert # Remove unnecessary type conversions
+    - unparam # Reports unused function parameters
+    - varcheck # Finds unused global variables and constants
+
+# Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
+# without names. If there is a memory issue on a specific field, that is best found with a heap profile.
+#linters-settings:
+#  govet:
+#    enable:
+#      - fieldalignment # detect Go structs that would take less memory if their fields were sorted
+
+# Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
+issues:
+  exclude-rules:
+    - path: (_test\.go|utilities_testing\.go)
+      linters:
+        - goconst

--- a/collate_test.go
+++ b/collate_test.go
@@ -11,6 +11,8 @@ package sgbucket
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type collateTest struct {
@@ -188,8 +190,8 @@ func BenchmarkParseAndCollate(b *testing.B) {
 		var collator JSONCollator
 		for _, test := range collateRawTests {
 			var left, right interface{}
-			json.Unmarshal(test.left.([]byte), &left)
-			json.Unmarshal(test.right.([]byte), &right)
+			require.NoError(b, json.Unmarshal(test.left.([]byte), &left))
+			require.NoError(b, json.Unmarshal(test.right.([]byte), &right))
 			result := collator.Collate(left, right)
 			if result != test.result {
 				panic("wrong result")

--- a/design_doc.go
+++ b/design_doc.go
@@ -19,7 +19,7 @@ type DesignDocOptions struct {
 	LocalSeq               bool `json:"local_seq,omitempty"`
 	IncludeDesign          bool `json:"include_design,omitempty"`
 	Raw                    bool `json:"raw,omitempty"`
-	IndexXattrOnTombstones bool `json:"index_xattr_on_deleted_docs, omitempty"`
+	IndexXattrOnTombstones bool `json:"index_xattr_on_deleted_docs,omitempty"`
 }
 
 // A Couchbase design document, which stores map/reduce function definitions.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sg-bucket
 
-go 1.17
+go 1.19
 
 require (
 	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f

--- a/go.sum
+++ b/go.sum
@@ -23,12 +23,8 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR3
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/couchbase/gocb.v1 v1.6.7 h1:Za2KhMBdo00+CKg4C09QetVziU8/N4YmQNwaPQqZWPg=

--- a/js_runner.go
+++ b/js_runner.go
@@ -79,12 +79,11 @@ func (runner *JSRunner) InitWithLogging(funcSource string, timeout time.Duration
 		return err
 	}
 
-	runner.js.Set("console", map[string]interface{}{
+	return runner.js.Set("console", map[string]interface{}{
 		"error": consoleErrorFunc,
 		"log":   consoleLogFunc,
 	})
 
-	return nil
 }
 
 func defaultLogFunction(s string) {
@@ -122,7 +121,7 @@ func (runner *JSRunner) SetTimeout(timeout time.Duration) {
 // This method is not thread-safe and should only be called before making any calls to the
 // main JS function.
 func (runner *JSRunner) DefineNativeFunction(name string, function NativeFunction) {
-	runner.js.Set(name, (func(otto.FunctionCall) otto.Value)(function))
+	_ = runner.js.Set(name, (func(otto.FunctionCall) otto.Value)(function))
 }
 
 func (runner *JSRunner) jsonToValue(jsonStr string) (interface{}, error) {

--- a/logg.go
+++ b/logg.go
@@ -15,7 +15,6 @@ import (
 	"sync/atomic"
 )
 
-
 // Set this to true to enable logging, 0 == false, >0 == true
 var logging uint32 = 0
 


### PR DESCRIPTION
- use go 1.19 to match sync gateway
- run go.mod tidy
- use .golangci.yml from sync gateway
- add golangci, race detector to github actions

- fixed lint errors (small ineffectual assignments, json tag issue)