### PR TITLE
CBG-1981 add contexts

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"errors"
 	"expvar"
 	"fmt"
@@ -74,7 +75,7 @@ type DynamicDataStoreBucket interface {
 // MutationFeedStore is a store that supports a DCP or TAP streaming mutation feed.
 type MutationFeedStore interface {
 	GetMaxVbno() (uint16, error)
-	StartDCPFeed(args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
+	StartDCPFeed(ctx context.Context, args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
 	StartTapFeed(args FeedArguments, dbStats *expvar.Map) (MutationFeed, error)
 }
 

--- a/tap.go
+++ b/tap.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package sgbucket
 
 import (
-	"context"
 	"math"
 	"time"
 )
@@ -69,4 +68,4 @@ const FeedResume = 1
 
 // FeedEventCallbackFunc performs mutation processing.  Return value indicates whether the mutation should trigger
 // checkpoint persistence (used to avoid recursive checkpoint document processing)
-type FeedEventCallbackFunc func(ctx context.Context, event FeedEvent) bool
+type FeedEventCallbackFunc func(event FeedEvent) bool

--- a/tap.go
+++ b/tap.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package sgbucket
 
 import (
+	"context"
 	"math"
 	"time"
 )
@@ -68,4 +69,4 @@ const FeedResume = 1
 
 // FeedEventCallbackFunc performs mutation processing.  Return value indicates whether the mutation should trigger
 // checkpoint persistence (used to avoid recursive checkpoint document processing)
-type FeedEventCallbackFunc func(event FeedEvent) bool
+type FeedEventCallbackFunc func(ctx context.Context, event FeedEvent) bool


### PR DESCRIPTION
Add contexts for logging.

I made the arbitrary decision to pass context as first parameter rather than adding as a feed argument because that is closer to a go idiom, and it forces the caller to make a decision.