### PR TITLE
changes needed in sg-bucket for macro expansion support to rosmar

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -156,7 +156,7 @@ type MutateInSpec struct {
 	Value interface{}
 }
 
-// UpsertSpec creates a upset spec for purpose for macro expansion mutate in operations
+// UpsertSpec creates a upsert spec for macro expansion mutate in operations
 func UpsertSpec(specPath string, val interface{}) MutateInSpec {
 	return MutateInSpec{
 		Path:  specPath,

--- a/bucket.go
+++ b/bucket.go
@@ -144,9 +144,24 @@ type UpsertOptions struct {
 	PreserveExpiry bool // GoCB v2 option
 }
 
-// MutateInOptions is a struct of options to pass in to SubdocUpdateBodyAndXattr
+// MutateInOptions is a struct of options for mutate in operations, to be used by both sync gateway rosmar
 type MutateInOptions struct {
 	PreserveExpiry bool // Used for imports - CBG-1563
+	Spec           []MutateInSpec
+}
+
+// MutateInSpec is a path, value pair where the path is a xattr path and the value to the value tio be injected into that place
+type MutateInSpec struct {
+	Path  string
+	Value interface{}
+}
+
+// UpsertSpec creates a upset spec for purpose for macro expansion mutate in operations
+func UpsertSpec(specPath string, val interface{}) MutateInSpec {
+	return MutateInSpec{
+		Path:  specPath,
+		Value: val,
+	}
 }
 
 // A KVStore implements the basic key-value CRUD operations.

--- a/bucket.go
+++ b/bucket.go
@@ -150,7 +150,7 @@ type MutateInOptions struct {
 	Spec           []MutateInSpec
 }
 
-// MutateInSpec is a path, value pair where the path is a xattr path and the value to the value tio be injected into that place
+// MutateInSpec is a path, value pair where the path is a xattr path and the value to  be injected into that place
 type MutateInSpec struct {
 	Path  string
 	Value interface{}


### PR DESCRIPTION
Small change to add a alias of mutate in options to sg-bucket. sg-bucket is a shared libray between sync gateway and rosmar so makes it convenient place to add this functionality.
Step trough changes:

1. MutateInSpec: simple path value struct for purpose of providing xattr path and a value to be upserted into that path 
2. MutateInOptions: change to add a list of the above specs to the options (this struct is passed down the stack in crud operations in sync gateway and rosmar)
3. UpsertSpec: helper function to create this spec by just passing the value and path to it (much like the function in gocb of the same name) 