### PR TITLE
Drop typed error during panic/recover handling for JS timeout

### DIFF
--- a/js_runner.go
+++ b/js_runner.go
@@ -24,8 +24,8 @@ type JSONString string
 
 type NativeFunction func(otto.FunctionCall) otto.Value
 
-// This specific instance will be returned if a call times out.
-var ErrJSTimeout = errors.New("javascript function timed out")
+// This specific error string will be raised with a panic if a call to the JS function times out.
+var ErrJSTimeout = "javascript function timed out"
 
 // Go interface to a JavaScript function (like a map/reduce/channelmap/validation function.)
 // Each JSServer object compiles a single function into a JavaScript runtime, and lets you
@@ -197,7 +197,7 @@ func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
 			defer func() {
 				if caught := recover(); caught != nil {
 					if caught == ErrJSTimeout {
-						err = ErrJSTimeout
+						err = errors.New(ErrJSTimeout)
 						return
 					}
 					panic(caught)

--- a/js_runner.go
+++ b/js_runner.go
@@ -217,7 +217,7 @@ func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
 					return
 				case <-timer.C:
 					runner.js.Interrupt <- func() {
-						panic(ErrJSTimeout)
+						panic(panicMsgTimeout)
 					}
 				}
 			}()


### PR DESCRIPTION
Drop typed error during panic/recover handling for JS timeout

Newer versions of Otto don't like the fact that a panic returns a struct (`errors.errorString`) - returning a string should be sufficient to properly panic/recover and identify a timeout.

See https://github.com/couchbase/sync_gateway/pull/6398#issuecomment-1710050755 for more info