### PR TITLE
CBG-3379 add contexts to pass log information

### DIFF
--- a/js_map_fn.go
+++ b/js_map_fn.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -71,18 +72,19 @@ type JSMapFunctionInput struct {
 	Xattrs map[string][]byte // Xattrs, each value marshaled to JSON
 }
 
-func NewJSMapFunction(fnSource string, timeout time.Duration) *JSMapFunction {
+func NewJSMapFunction(ctx context.Context, fnSource string, timeout time.Duration) *JSMapFunction {
 	return &JSMapFunction{
-		JSServer: NewJSServer(fnSource, timeout, kTaskCacheSize,
-			func(fnSource string, timeout time.Duration) (JSServerTask, error) {
+		JSServer: NewJSServer(ctx, fnSource, timeout, kTaskCacheSize,
+			func(ctx context.Context, fnSource string, timeout time.Duration) (JSServerTask, error) {
 				return newJsMapTask(fnSource, timeout)
 			}),
 	}
 }
 
 // Calls a jsMapTask.
-func (mapper *JSMapFunction) CallFunction(input *JSMapFunctionInput) ([]*ViewRow, error) {
-	result1, err := mapper.Call(JSONString(input.Doc), MakeMeta(input))
+func (mapper *JSMapFunction) CallFunction(ctx context.Context, input *JSMapFunctionInput) ([]*ViewRow, error) {
+	fmt.Println(JSONString(input.Doc))
+	result1, err := mapper.Call(ctx, JSONString(input.Doc), MakeMeta(input))
 	if err != nil {
 		return nil, err
 	}

--- a/js_runner.go
+++ b/js_runner.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -146,7 +147,7 @@ func (runner *JSRunner) CallWithJSON(inputs ...string) (interface{}, error) {
 	if runner.Before != nil {
 		runner.Before()
 	}
-
+	fmt.Println("inputs=", inputs)
 	var result otto.Value
 	var err error
 	if runner.fn.IsUndefined() {
@@ -168,10 +169,11 @@ func (runner *JSRunner) CallWithJSON(inputs ...string) (interface{}, error) {
 }
 
 // Invokes the JS function with Go inputs.
-func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
+func (runner *JSRunner) Call(ctx context.Context, inputs ...interface{}) (_ interface{}, err error) {
 	if runner.Before != nil {
 		runner.Before()
 	}
+	fmt.Println("non JSON inputs=", inputs)
 
 	var result otto.Value
 	if runner.fn.IsUndefined() {
@@ -184,6 +186,7 @@ func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
 					return nil, err
 				}
 			}
+			fmt.Println("input", input)
 			inputJS[i], err = runner.js.ToValue(input)
 			if err != nil {
 				return nil, fmt.Errorf("Couldn't convert %#v to JS: %s", input, err)
@@ -219,8 +222,11 @@ func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
 				}
 			}()
 		}
+		fmt.Println("inputJS", inputJS)
+		fmt.Printf("\nrunner %+v", runner.fn)
 
 		result, err = runner.fn.Call(runner.fn, inputJS...)
+		fmt.Println("err=", err)
 		if completed != nil {
 			close(completed)
 		}

--- a/queries.go
+++ b/queries.go
@@ -8,7 +8,10 @@
 
 package sgbucket
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Identifies query languages understood by QueryableStore objects.
 type QueryLanguage string
@@ -66,10 +69,10 @@ type QueryableStore interface {
 // implemented by sgbucket.ViewResult, gocb.ViewResults, and gocb.QueryResults
 type QueryResultIterator interface {
 	// Unmarshals a single result row into valuePtr, and then closes the iterator.
-	One(valuePtr any) error
+	One(ctx context.Context, valuePtr any) error
 	// Unmarshals the next result row into valuePtr.
 	// Returns false when reaching end of result set.
-	Next(valuePtr any) bool
+	Next(ctx context.Context, valuePtr any) bool
 	// Retrieves raw JSON bytes for the next result row.
 	NextBytes() []byte
 	// Closes the iterator.  Returns any row-level errors seen during iteration.


### PR DESCRIPTION
Pass context information through interfaces that are necessary for sync gateway to store context information at a keyspace scope.