### PR TITLE
[3.1.2 backport] CBG-3379 add contexts for log information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,11 @@
+# Copyright 2023-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 name: ci
 
 on:
@@ -7,12 +15,24 @@ on:
       - 'release/*'
       - 'CBG*'
       - 'ci-*'
+      - 'feature*'
   pull_request:
     branches:
       - 'master'
       - 'release/*'
 
 jobs:
+  addlicense:
+    name: addlicense
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.3
+      - run: go install github.com/google/addlicense@latest
+      - uses: actions/checkout@v3
+      - run: addlicense -check -f licenses/addlicense.tmpl .
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -25,7 +45,7 @@ jobs:
       - name: Setup Go Faster
         uses: WillAbides/setup-go-faster@v1.8.0
         with:
-          go-version: ^1.19.5 # >=1.17.5, <2.0.0
+          go-version: 1.20.3
       - uses: actions/checkout@v2
       - name: Build
         run: go build -v "./..."
@@ -44,12 +64,12 @@ jobs:
     steps:
       - uses: WillAbides/setup-go-faster@v1.8.0
         with:
-          go-version: 1.19.5
+          go-version: 1.20.3
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.52.0
 
   test-race:
     runs-on: ubuntu-latest
@@ -58,7 +78,7 @@ jobs:
     steps:
       - uses: WillAbides/setup-go-faster@v1.8.0
         with:
-          go-version: 1.19.5
+          go-version: 1.20.3
       - uses: actions/checkout@v3
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'

--- a/bucket.go
+++ b/bucket.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"errors"
 	"expvar"
 	"fmt"
@@ -74,7 +75,7 @@ type DynamicDataStoreBucket interface {
 // MutationFeedStore is a store that supports a DCP or TAP streaming mutation feed.
 type MutationFeedStore interface {
 	GetMaxVbno() (uint16, error)
-	StartDCPFeed(args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
+	StartDCPFeed(ctx context.Context, args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
 	StartTapFeed(args FeedArguments, dbStats *expvar.Map) (MutationFeed, error)
 }
 

--- a/bucket.go
+++ b/bucket.go
@@ -55,7 +55,7 @@ const (
 type BucketStore interface {
 	GetName() string       // GetName returns the Bucket name
 	UUID() (string, error) // UUID returns a UUID for the bucket
-	Close()                // Close closes the bucket
+	Close(context.Context) // Close closes the bucket
 
 	ListDataStores() ([]DataStoreName, error)        // ListDataStores returns a list of all DataStore names in the bucket
 	DefaultDataStore() DataStore                     // DefaultDataStore returns the default data store for the bucket
@@ -68,8 +68,8 @@ type BucketStore interface {
 
 // DynamicDataStoreBucket is an interface that describes a bucket that can change its set of DataStores.
 type DynamicDataStoreBucket interface {
-	CreateDataStore(DataStoreName) error // CreateDataStore creates a new DataStore in the bucket
-	DropDataStore(DataStoreName) error   // DropDataStore drops a DataStore from the bucket
+	CreateDataStore(context.Context, DataStoreName) error // CreateDataStore creates a new DataStore in the bucket
+	DropDataStore(DataStoreName) error                    // DropDataStore drops a DataStore from the bucket
 }
 
 // MutationFeedStore is a store that supports a DCP or TAP streaming mutation feed.
@@ -125,42 +125,42 @@ type KVStore interface {
 	Remove(k string, cas uint64) (casOut uint64, err error)
 	Update(k string, exp uint32, callback UpdateFunc) (casOut uint64, err error)
 	Incr(k string, amt, def uint64, exp uint32) (uint64, error)
-	GetExpiry(k string) (expiry uint32, err error)
+	GetExpiry(ctx context.Context, k string) (expiry uint32, err error)
 	Exists(k string) (exists bool, err error)
 }
 
 // SubdocStore describes methods that can be used to operate on parts of a document with a subdoc operation.
 type SubdocStore interface {
-	SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error
-	GetSubDocRaw(k string, subdocKey string) (value []byte, casOut uint64, err error)
-	WriteSubDoc(k string, subdocKey string, cas uint64, value []byte) (casOut uint64, err error)
+	SubdocInsert(ctx context.Context, docID string, fieldPath string, cas uint64, value interface{}) error
+	GetSubDocRaw(ctx context.Context, k string, subdocKey string) (value []byte, casOut uint64, err error)
+	WriteSubDoc(ctx context.Context, k string, subdocKey string, cas uint64, value []byte) (casOut uint64, err error)
 }
 
 // A ViewStore is a data store with a map-reduce query interface.
 type ViewStore interface {
 	GetDDoc(docname string) (DesignDoc, error)
 	GetDDocs() (map[string]DesignDoc, error)
-	PutDDoc(docname string, value *DesignDoc) error
+	PutDDoc(ctx context.Context, docname string, value *DesignDoc) error
 	DeleteDDoc(docname string) error
 
 	// View issues a view query, and returns the results as a ViewResult
-	View(ddoc, name string, params map[string]interface{}) (ViewResult, error)
+	View(ctx context.Context, ddoc, name string, params map[string]interface{}) (ViewResult, error)
 
 	// ViewQuery issues a view query, and returns an iterator supporting row-level unmarshalling of the results.
-	ViewQuery(ddoc, name string, params map[string]interface{}) (QueryResultIterator, error)
+	ViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (QueryResultIterator, error)
 }
 
 // An XattrStore is a data store that supports extended attributes
 type XattrStore interface {
-	WriteCasWithXattr(k string, xattrKey string, exp uint32, cas uint64, opts *MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error)
-	WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, opts *MutateInOptions, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error)
-	SetXattr(k string, xattrKey string, xv []byte) (casOut uint64, err error)
-	RemoveXattr(k string, xattrKey string, cas uint64) (err error)
-	DeleteXattrs(k string, xattrKeys ...string) (err error)
-	GetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error)
-	GetWithXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error)
-	DeleteWithXattr(k string, xattrKey string) error
-	WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, opts *MutateInOptions, previous *BucketDocument, callback WriteUpdateWithXattrFunc) (casOut uint64, err error)
+	WriteCasWithXattr(ctx context.Context, k string, xattrKey string, exp uint32, cas uint64, opts *MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error)
+	WriteWithXattr(ctx context.Context, k string, xattrKey string, exp uint32, cas uint64, opts *MutateInOptions, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error)
+	SetXattr(ctx context.Context, k string, xattrKey string, xv []byte) (casOut uint64, err error)
+	RemoveXattr(ctx context.Context, k string, xattrKey string, cas uint64) (err error)
+	DeleteXattrs(ctx context.Context, k string, xattrKeys ...string) (err error)
+	GetXattr(ctx context.Context, k string, xattrKey string, xv interface{}) (casOut uint64, err error)
+	GetWithXattr(ctx context.Context, k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error)
+	DeleteWithXattr(ctx context.Context, k string, xattrKey string) error
+	WriteUpdateWithXattr(kctx context.Context, string, xattrKey string, userXattrKey string, exp uint32, opts *MutateInOptions, previous *BucketDocument, callback WriteUpdateWithXattrFunc) (casOut uint64, err error)
 }
 
 // A DeletableStore is a data store that supports deletion of the underlying store.
@@ -175,10 +175,10 @@ type FlushableStore interface {
 
 // Common query iterator interface,  implemented by sgbucket.ViewResult, gocb.ViewResults, and gocb.QueryResults
 type QueryResultIterator interface {
-	One(valuePtr interface{}) error // Unmarshal a single result row into valuePtr, and then close the iterator
-	Next(valuePtr interface{}) bool // Unmarshal the next result row into valuePtr.  Returns false when reaching end of result set
-	NextBytes() []byte              // Retrieve raw bytes for the next result row
-	Close() error                   // Closes the iterator.  Returns any row-level errors seen during iteration.
+	One(ctx context.Context, valuePtr interface{}) error // Unmarshal a single result row into valuePtr, and then close the iterator
+	Next(ctx context.Context, valuePtr interface{}) bool // Unmarshal the next result row into valuePtr.  Returns false when reaching end of result set
+	NextBytes() []byte                                   // Retrieve raw bytes for the next result row
+	Close() error                                        // Closes the iterator.  Returns any row-level errors seen during iteration.
 }
 
 // A set of option flags for the Write method.

--- a/js_map_fn.go
+++ b/js_map_fn.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -62,18 +63,18 @@ type JSMapFunction struct {
 	*JSServer
 }
 
-func NewJSMapFunction(fnSource string, timeout time.Duration) *JSMapFunction {
+func NewJSMapFunction(ctx context.Context, fnSource string, timeout time.Duration) *JSMapFunction {
 	return &JSMapFunction{
-		JSServer: NewJSServer(fnSource, timeout, kTaskCacheSize,
-			func(fnSource string, timeout time.Duration) (JSServerTask, error) {
+		JSServer: NewJSServer(ctx, fnSource, timeout, kTaskCacheSize,
+			func(ctx context.Context, fnSource string, timeout time.Duration) (JSServerTask, error) {
 				return newJsMapTask(fnSource, timeout)
 			}),
 	}
 }
 
 // Calls a jsMapTask.
-func (mapper *JSMapFunction) CallFunction(doc string, docid string, vbNo uint32, vbSeq uint64) ([]*ViewRow, error) {
-	result1, err := mapper.Call(JSONString(doc), MakeMeta(docid, vbNo, vbSeq))
+func (mapper *JSMapFunction) CallFunction(ctx context.Context, doc string, docid string, vbNo uint32, vbSeq uint64) ([]*ViewRow, error) {
+	result1, err := mapper.Call(ctx, JSONString(doc), MakeMeta(docid, vbNo, vbSeq))
 	if err != nil {
 		return nil, err
 	}

--- a/js_runner.go
+++ b/js_runner.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -168,7 +169,7 @@ func (runner *JSRunner) CallWithJSON(inputs ...string) (interface{}, error) {
 }
 
 // Invokes the JS function with Go inputs.
-func (runner *JSRunner) Call(inputs ...interface{}) (_ interface{}, err error) {
+func (runner *JSRunner) Call(_ context.Context, inputs ...interface{}) (_ interface{}, err error) {
 	if runner.Before != nil {
 		runner.Before()
 	}

--- a/js_server.go
+++ b/js_server.go
@@ -9,6 +9,7 @@
 package sgbucket
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -25,17 +26,17 @@ type JSServer struct {
 // Abstract interface for a callable interpreted function. JSRunner implements this.
 type JSServerTask interface {
 	SetFunction(funcSource string) (bool, error)
-	Call(inputs ...interface{}) (interface{}, error)
+	Call(ctx context.Context, inputs ...interface{}) (interface{}, error)
 }
 
 // Factory function that creates JSServerTasks.
-type JSServerTaskFactory func(fnSource string, timeout time.Duration) (JSServerTask, error)
+type JSServerTaskFactory func(ctx context.Context, fnSource string, timeout time.Duration) (JSServerTask, error)
 
 // Creates a new JSServer that will run a JavaScript function.
 // 'funcSource' should look like "function(x,y) { ... }"
-func NewJSServer(funcSource string, timeout time.Duration, maxTasks int, factory JSServerTaskFactory) *JSServer {
+func NewJSServer(_ context.Context, funcSource string, timeout time.Duration, maxTasks int, factory JSServerTaskFactory) *JSServer {
 	if factory == nil {
-		factory = func(fnSource string, timeout time.Duration) (JSServerTask, error) {
+		factory = func(_ context.Context, fnSource string, timeout time.Duration) (JSServerTask, error) {
 			return NewJSRunner(fnSource, timeout)
 		}
 	}
@@ -65,13 +66,13 @@ func (server *JSServer) SetFunction(fnSource string) (bool, error) {
 	return true, nil
 }
 
-func (server *JSServer) getTask() (task JSServerTask, err error) {
+func (server *JSServer) getTask(ctx context.Context) (task JSServerTask, err error) {
 	fnSource := server.Function()
 	select {
 	case task = <-server.tasks:
 		_, err = task.SetFunction(fnSource)
 	default:
-		task, err = server.factory(fnSource, server.timeout)
+		task, err = server.factory(ctx, fnSource, server.timeout)
 	}
 	return
 }
@@ -86,8 +87,8 @@ func (server *JSServer) returnTask(task JSServerTask) {
 
 type WithTaskFunc func(JSServerTask) (interface{}, error)
 
-func (server *JSServer) WithTask(fn WithTaskFunc) (interface{}, error) {
-	task, err := server.getTask()
+func (server *JSServer) WithTask(ctx context.Context, fn WithTaskFunc) (interface{}, error) {
+	task, err := server.getTask(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -100,12 +101,12 @@ func (server *JSServer) WithTask(fn WithTaskFunc) (interface{}, error) {
 // passed as parameters to the function.
 // The output value will be nil unless a custom 'After' function has been installed, in which
 // case it'll be the result of that function.
-func (server *JSServer) CallWithJSON(jsonParams ...string) (interface{}, error) {
+func (server *JSServer) CallWithJSON(ctx context.Context, jsonParams ...string) (interface{}, error) {
 	goParams := make([]JSONString, len(jsonParams))
 	for i, str := range jsonParams {
 		goParams[i] = JSONString(str)
 	}
-	return server.Call(goParams)
+	return server.Call(ctx, goParams)
 }
 
 // Public thread-safe entry point for invoking the JS function.
@@ -113,8 +114,8 @@ func (server *JSServer) CallWithJSON(jsonParams ...string) (interface{}, error) 
 // JSON can be passed in as a value of type JSONString (a wrapper type for string.)
 // The output value will be nil unless a custom 'After' function has been installed, in which
 // case it'll be the result of that function.
-func (server *JSServer) Call(goParams ...interface{}) (interface{}, error) {
-	return server.WithTask(func(task JSServerTask) (interface{}, error) {
-		return task.Call(goParams...)
+func (server *JSServer) Call(ctx context.Context, goParams ...interface{}) (interface{}, error) {
+	return server.WithTask(ctx, func(task JSServerTask) (interface{}, error) {
+		return task.Call(ctx, goParams...)
 	})
 }

--- a/licenses/addlicense.tmpl
+++ b/licenses/addlicense.tmpl
@@ -1,0 +1,7 @@
+Copyright {{.Year}}-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included
+in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+in that file, in accordance with the Business Source License, use of this
+software will be governed by the Apache License, Version 2.0, included in
+the file licenses/APL2.txt.

--- a/views.go
+++ b/views.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package sgbucket
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -294,7 +295,7 @@ func (r *ViewResult) NextBytes() []byte {
 
 }
 
-func (r *ViewResult) Next(valuePtr interface{}) bool {
+func (r *ViewResult) Next(_ context.Context, valuePtr interface{}) bool {
 	if len(r.Errors) > 0 || r.iterErr != nil {
 		return false
 	}
@@ -324,8 +325,8 @@ func (r *ViewResult) Close() error {
 	return nil
 }
 
-func (r *ViewResult) One(valuePtr interface{}) error {
-	if !r.Next(valuePtr) {
+func (r *ViewResult) One(ctx context.Context, valuePtr interface{}) error {
+	if !r.Next(ctx, valuePtr) {
 		err := r.Close()
 		if err != nil {
 			return err


### PR DESCRIPTION
This is a backport of https://github.com/couchbase/sg-bucket/pull/105. It had to be redone because of rosmar changes and changes to javascript interfaces.