### PR TITLE
CBG-3448: update WriteUpdateWithXattrFunc definition

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -539,10 +539,12 @@ type UpdateFunc func(current []byte) (updated []byte, expiry *uint32, delete boo
 // - xattr: Current value of requested xattr
 // - userXattr: Current value of requested user xattr (if any)
 // - cas: Document's current CAS
+// - inputOpts: Current mutate in options
 // Return values:
 // - updatedDoc: New value to store (or nil to leave unchanged)
 // - updatedXattr: New xattr value to store (or nil to leave unchanged)
 // - deleteDoc: If true, document should be deleted
 // - expiry: If non-nil, points to a new expiry timestamp
+// - opts: Updated mutate in options based off logic performed on the document
 // - err: If non-nil, cancels update.
-type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, opts []MacroExpansionSpec, err error)
+type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, inputOpts *MutateInOptions, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, opts *MutateInOptions, err error)

--- a/bucket.go
+++ b/bucket.go
@@ -545,4 +545,4 @@ type UpdateFunc func(current []byte) (updated []byte, expiry *uint32, delete boo
 // - deleteDoc: If true, document should be deleted
 // - expiry: If non-nil, points to a new expiry timestamp
 // - err: If non-nil, cancels update.
-type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, err error)
+type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, opts []MacroExpansionSpec, err error)

--- a/bucket.go
+++ b/bucket.go
@@ -544,6 +544,6 @@ type UpdateFunc func(current []byte) (updated []byte, expiry *uint32, delete boo
 // - updatedXattr: New xattr value to store (or nil to leave unchanged)
 // - deleteDoc: If true, document should be deleted
 // - expiry: If non-nil, points to a new expiry timestamp
-// - updatedSpec: Updated mutate in spec based off logic performed on the document insdie callback
+// - updatedSpec: Updated mutate in spec based off logic performed on the document inside callback
 // - err: If non-nil, cancels update.
 type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, updatedSpec []MacroExpansionSpec, err error)

--- a/bucket.go
+++ b/bucket.go
@@ -539,12 +539,11 @@ type UpdateFunc func(current []byte) (updated []byte, expiry *uint32, delete boo
 // - xattr: Current value of requested xattr
 // - userXattr: Current value of requested user xattr (if any)
 // - cas: Document's current CAS
-// - inputOpts: Current mutate in options
 // Return values:
 // - updatedDoc: New value to store (or nil to leave unchanged)
 // - updatedXattr: New xattr value to store (or nil to leave unchanged)
 // - deleteDoc: If true, document should be deleted
 // - expiry: If non-nil, points to a new expiry timestamp
-// - opts: Updated mutate in options based off logic performed on the document
+// - updatedSpec: Updated mutate in spec based off logic performed on the document insdie callback
 // - err: If non-nil, cancels update.
-type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, inputOpts *MutateInOptions, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, opts *MutateInOptions, err error)
+type WriteUpdateWithXattrFunc func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deleteDoc bool, expiry *uint32, updatedSpec []MacroExpansionSpec, err error)


### PR DESCRIPTION
CBG-3448

We need to to able to update these mutate in options based off logic performed on the HLV. This provides a change to allow us to perform this logic in callback functions used in sync gateway. 

Exact change is having the already defined mutate in options passed into the functions and have the updated mutate in options returned out of the function. 
