### PR TITLE
Add UserXattrStore to DataStore to avoid type casts

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -36,6 +36,7 @@ const (
 	BucketStoreFeaturePreserveExpiry
 	BucketStoreFeatureCollections
 	BucketStoreFeatureSystemCollections
+	BucketStoreFeatureMobileXDCR
 )
 
 // An error type, used by TypedErrorStore.IsError

--- a/bucket.go
+++ b/bucket.go
@@ -127,6 +127,7 @@ type DataStore interface {
 	KVStore
 	XattrStore
 	SubdocStore
+	UserXattrStore
 	TypedErrorStore
 	BucketStoreFeatureIsSupported
 }

--- a/tap.go
+++ b/tap.go
@@ -28,6 +28,21 @@ const (
 	FeedOpDeletion                         // A document was deleted
 )
 
+func (o FeedOpcode) String() string {
+	switch o {
+	case FeedOpBeginBackfill:
+		return "BeginBackfill"
+	case FeedOpEndBackfill:
+		return "EndBackfill"
+	case FeedOpMutation:
+		return "Mutation"
+	case FeedOpDeletion:
+		return "Deletion"
+	default:
+		return fmt.Sprintf("Opcode(%d)", o)
+	}
+}
+
 type FeedDataType = uint8
 
 const FeedDataTypeRaw FeedDataType = 0 // raw (binary) document


### PR DESCRIPTION
Add `UserXattrStore` to `DataStore` since rosmar supports this feature.

Unrelatedly, also add a new feature for mobile XDCR (available in 7.6.1) and a string debugging for DCP events.