### PR TITLE
CBG-3703 add options for XDCR

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -72,14 +72,6 @@ type DynamicDataStoreBucket interface {
 	DropDataStore(DataStoreName) error                    // DropDataStore drops a DataStore from the bucket
 }
 
-// A type of feed, either TCP or the older TAP
-type FeedType string
-
-const (
-	DcpFeedType FeedType = "dcp"
-	TapFeedType FeedType = "tap"
-)
-
 // MutationFeedStore is a DataStore that supports a DCP or TAP streaming mutation feed.
 type MutationFeedStore interface {
 	// The number of vbuckets of this store; usually 1024.
@@ -91,19 +83,6 @@ type MutationFeedStore interface {
 	// - callback: The function to be called for each event.
 	// - dbStats: TODO: What does this do? Walrus ignores it.
 	StartDCPFeed(ctx context.Context, args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
-
-	// Starts a new TAP event feed. Events can be read from the returned MutationFeed's
-	// Events channel. The feed is closed by calling the MutationFeed's Close function.
-	// - args: Configures what events will be sent.
-	// - dbStats: TODO: What does this do? Walrus ignores it.
-	StartTapFeed(args FeedArguments, dbStats *expvar.Map) (MutationFeed, error)
-}
-
-// An extension of MutationFeedStore.
-type MutationFeedStore2 interface {
-	MutationFeedStore
-	// The type of feed supported by this data store.
-	GetFeedType() FeedType
 }
 
 // A DataStore that can introspect the errors it returns.

--- a/bucket.go
+++ b/bucket.go
@@ -120,24 +120,19 @@ type BucketStoreFeatureIsSupported interface {
 // A Couchbase Server collection within a bucket is an example of a DataStore.
 // The expiry field (exp) can take offsets or UNIX Epoch times.  See https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/doc-expiration.html
 type DataStore interface {
-	// The datastore name (usually a qualified collection name)
+	// The datastore name (usually a qualified collection name, bucket.scope.collection)
 	GetName() string
-	// DataStoreName() DataStoreName // TODO: Implement later
+	// The name of the datastore, without the bucket name
+	DataStoreName() DataStoreName
 
+	// An integer that uniquely identifies this Collection in its Bucket.
+	// The default collection always has the ID zero.
+	GetCollectionID() uint32
 	KVStore
 	XattrStore
 	SubdocStore
 	TypedErrorStore
 	BucketStoreFeatureIsSupported
-}
-
-// A Collection is the typical type of DataStore. It has an integer identifier.
-type Collection interface {
-	// An integer that uniquely identifies this Collection in its Bucket.
-	// The default collection always has the ID zero.
-	GetCollectionID() uint32
-
-	DataStore
 }
 
 // UpsertOptions are the options to use with the set operations

--- a/bucket.go
+++ b/bucket.go
@@ -122,8 +122,6 @@ type BucketStoreFeatureIsSupported interface {
 type DataStore interface {
 	// The datastore name (usually a qualified collection name, bucket.scope.collection)
 	GetName() string
-	// The name of the datastore, without the bucket name
-	DataStoreName() DataStoreName
 
 	// An integer that uniquely identifies this Collection in its Bucket.
 	// The default collection always has the ID zero.
@@ -133,6 +131,7 @@ type DataStore interface {
 	SubdocStore
 	TypedErrorStore
 	BucketStoreFeatureIsSupported
+	DataStoreName
 }
 
 // UpsertOptions are the options to use with the set operations

--- a/sync_metadata.go
+++ b/sync_metadata.go
@@ -1,0 +1,14 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package sgbucket
+
+const (
+	SyncDocPrefix = "_sync:"                // SyncDocPrefix is a document prefix for all sync metadata
+	Att2Prefix    = SyncDocPrefix + "att2:" // Att2Prefix is a document prefix for v2 attachment data
+)

--- a/tap.go
+++ b/tap.go
@@ -66,7 +66,7 @@ type FeedEvent struct {
 	TimeReceived time.Time    // Used for latency calculations
 }
 
-// A Tap feed. Events from the bucket can be read from the channel returned by Events().
+// MutationFeed shows events from the bucket can be read from the channel returned by Events().
 // Remember to call Close() on it when you're done, unless its channel has closed itself already.
 type MutationFeed interface {
 	Events() <-chan FeedEvent      // Read only channel to read TapEvents

--- a/xdcr.go
+++ b/xdcr.go
@@ -18,6 +18,9 @@ type XDCRStats struct {
 	DocsWritten uint64
 	// ErrorCount is the number of errors that have occurred during the replication.
 	ErrorCount uint64
+
+	// TargetNewerDocs is the number of documents that were newer on the target cluster than the source cluster.
+	TargetNewerDocs uint64
 }
 
 // XDCR represents a bucket to bucket XDCR replication.

--- a/xdcr.go
+++ b/xdcr.go
@@ -1,0 +1,59 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package sgbucket
+
+import "context"
+
+// XDCRStats represents the stats of a replication.
+type XDCRStats struct {
+	// DocsFiltered is the number of documents that have been filtered out and have not been replicated to the target cluster.
+	DocsFiltered uint64
+	// DocsWritten is the number of documents written to the destination cluster, since the start or resumption of the current replication.
+	DocsWritten uint64
+	// ErrorCount is the number of errors that have occurred during the replication.
+	ErrorCount uint64
+}
+
+// XDCR represents a bucket to bucket XDCR replication.
+type XDCR interface {
+	// Start starts the replication.
+	Start(context.Context) error
+	// Stop terminates the replication.
+	Stop(context.Context) error
+	// Stats returns the stats for the replication.
+	Stats(context.Context) (*XDCRStats, error)
+}
+
+// XDcrManager represents the presence of "-mobile" flag for Couchbase Server replications. -mobile implies filtering sync metadata, handling version vectors, and filtering sync documents.
+type XDCRMobileSetting uint8
+
+const (
+	XDCRMobileOff = iota
+	XDCRMobileOn
+)
+
+// String returns the string representation of the XDCRMobileSetting, used for directly passing on to the Couchbase Server REST API.
+func (s XDCRMobileSetting) String() string {
+	switch s {
+	case XDCRMobileOff:
+		return "Off"
+	case XDCRMobileOn:
+		return "Active"
+	default:
+		return "Unknown"
+	}
+}
+
+// XDCROptions represents the options for creating an XDCR.
+type XDCROptions struct {
+	// FilterExpression is the filter expression to use for the replication.
+	FilterExpression string
+	// XDCR mobile setting defines whether XDCR replication will use -mobile setting behavior in Couchbase Server.
+	Mobile XDCRMobileSetting
+}


### PR DESCRIPTION
- putting options for XDCR in sg-bucket allows full XDCR implementation to be in rosmar
- place sync metadata constants into sg-bucket for rosmar

This includes https://github.com/couchbase/sg-bucket/pull/119 which can be merged separately to simplify interfaces.