### PR TITLE
Simplify interfaces to have fewer casts

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -72,14 +72,6 @@ type DynamicDataStoreBucket interface {
 	DropDataStore(DataStoreName) error                    // DropDataStore drops a DataStore from the bucket
 }
 
-// A type of feed, either TCP or the older TAP
-type FeedType string
-
-const (
-	DcpFeedType FeedType = "dcp"
-	TapFeedType FeedType = "tap"
-)
-
 // MutationFeedStore is a DataStore that supports a DCP or TAP streaming mutation feed.
 type MutationFeedStore interface {
 	// The number of vbuckets of this store; usually 1024.
@@ -91,19 +83,6 @@ type MutationFeedStore interface {
 	// - callback: The function to be called for each event.
 	// - dbStats: TODO: What does this do? Walrus ignores it.
 	StartDCPFeed(ctx context.Context, args FeedArguments, callback FeedEventCallbackFunc, dbStats *expvar.Map) error
-
-	// Starts a new TAP event feed. Events can be read from the returned MutationFeed's
-	// Events channel. The feed is closed by calling the MutationFeed's Close function.
-	// - args: Configures what events will be sent.
-	// - dbStats: TODO: What does this do? Walrus ignores it.
-	StartTapFeed(args FeedArguments, dbStats *expvar.Map) (MutationFeed, error)
-}
-
-// An extension of MutationFeedStore.
-type MutationFeedStore2 interface {
-	MutationFeedStore
-	// The type of feed supported by this data store.
-	GetFeedType() FeedType
 }
 
 // A DataStore that can introspect the errors it returns.
@@ -122,22 +101,17 @@ type BucketStoreFeatureIsSupported interface {
 type DataStore interface {
 	// The datastore name (usually a qualified collection name)
 	GetName() string
-	// DataStoreName() DataStoreName // TODO: Implement later
+
+	// An integer that uniquely identifies this Collection in its Bucket.
+	// The default collection always has the ID zero.
+	GetCollectionID() uint32
 
 	KVStore
 	XattrStore
 	SubdocStore
 	TypedErrorStore
 	BucketStoreFeatureIsSupported
-}
-
-// A Collection is the typical type of DataStore. It has an integer identifier.
-type Collection interface {
-	// An integer that uniquely identifies this Collection in its Bucket.
-	// The default collection always has the ID zero.
-	GetCollectionID() uint32
-
-	DataStore
+	DataStoreName
 }
 
 // UpsertOptions are the options to use with the set operations

--- a/tap.go
+++ b/tap.go
@@ -66,7 +66,7 @@ type FeedEvent struct {
 	TimeReceived time.Time    // Used for latency calculations
 }
 
-// A Tap feed. Events from the bucket can be read from the channel returned by Events().
+// MutationFeed shows events from the bucket can be read from the channel returned by Events().
 // Remember to call Close() on it when you're done, unless its channel has closed itself already.
 type MutationFeed interface {
 	Events() <-chan FeedEvent      // Read only channel to read TapEvents


### PR DESCRIPTION
- Drop MutationFeedStore2 since the only implementations used by gocb and rosmar are DCP
- Merged DataStoreName (ScopeName(),CollectionName()) into DataStore, and add CollectionID to DataStore