### PR TITLE
Update golangci-lint and packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.21.9
+          go-version: 1.24.10
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -40,10 +40,10 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.21.9
+          go-version: 1.24.10
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -59,14 +59,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.21.9
+          go-version: 1.24.10
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.57.2
+          version: v2.6.2
 
   test-race:
     runs-on: ${{ matrix.os }}
@@ -75,10 +75,10 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.21.9
+          go-version: 1.24.10
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           go-version: 1.24.10
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.6.2
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,90 +1,120 @@
-# Copyright 2020-Present Couchbase, Inc.
+# Copyright 2025-Present Couchbase, Inc.
 #
-# Use of this software is governed by the Business Source License included in
-# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
-# file, in accordance with the Business Source License, use of this software
-# will be governed by the Apache License, Version 2.0, included in the file
-# licenses/APL2.txt.
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
 
-# config file for golangci-lint
-
+version: "2"
 linters:
   enable:
-    #- bodyclose # checks whether HTTP response body is closed successfully
-    #- dupl # Tool for code clone detection
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    #- goconst # Finds repeated strings that could be replaced by a constant
-    #- gocritic # The most opinionated Go source code linter
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
-    #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    #- gosec # (gas) Inspects source code for security problems
-    #- gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    #- ineffassign # Detects when assignments to existing variables are not used
-    - misspell # Finds commonly misspelled English words in comments
-    #- nakedret # Finds naked returns in functions greater than a specified function length
-    #- prealloc # Finds slice declarations that could potentially be preallocated
-    #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    #- staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    #- structcheck # Finds unused struct fields - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    #- unconvert # Remove unnecessary type conversions
-    #- unparam # Reports unused function parameters
-    #- unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-  disable:
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - gocognit # Computes and checks the cognitive complexity of functions
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - godot # Check if comments end in a period
-    - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113 # Golang linter to check the errors handling expressions
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
-    - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - interfacer # Linter that suggests narrower interface types
-    - lll # Reports long lines
-    - nestif # Reports deeply nested if statements
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - scopelint # Scopelint checks for unpinned variables in go programs
-    - stylecheck # Stylecheck is a replacement for golint
-    - testpackage # linter that makes you use a separate _test package
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Whitespace Linter - Forces you to use empty lines!
-    # Once fixed, should enable
     - bodyclose # checks whether HTTP response body is closed successfully
-    - deadcode # Finds unused code
     - dupl # Tool for code clone detection
     - goconst # Finds repeated strings that could be replaced by a constant
     - gocritic # The most opinionated Go source code linter
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec # (gas) Inspects source code for security problems
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - ineffassign # Detects when assignments to existing variables are not used
-    - nakedret # Finds naked returns in functions greater than a specified function length
+    - gosec # Inspects source code for security problems
+    - misspell # Finds commonly misspelled English words in comments
+    #- nakedret # Finds naked returns in functions greater than a specified function length
     - prealloc # Finds slice declarations that could potentially be preallocated
     - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck # Finds unused struct fields
     - unconvert # Remove unnecessary type conversions
-    - unparam # Reports unused function parameters
-    - varcheck # Finds unused global variables and constants
+    # - unparam # Reports unused function parameters
+  settings:
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - ifElseChain
+        - valSwap
+    gosec:
+      excludes:
+        - G115 # integer overflow conversion
+    # fieldalignment needs special effort to decide or not
+    # govet:
+    #  enable:
+    #    - fieldalignment
+    revive:
+      enable-all-rules: true
+      rules:
+        - name: add-constant # avoid magic numbers, picked up by goconst linter
+          disabled: true
+        - name: bare-return
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: comment-spacings # no space between comment delimiter and comment text
+          disabled: true
+        - name: confusing-naming # Method differs only be capitalization in same source file
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: early-return
+          disabled: true
+        - name: enforce-switch-style # switch must have a default case
+          disabled: true
+        - name: exported # Exported function and methods should have comments
+          disabled: true
+        - name: empty-lines # extra empty line at start of a block
+          disabled: true
+        - name: error-strings # errors strings should not be capitalized or end with punctuation or a newline
+          disabled: true
+        - name: flag-parameter # parameter seems to be a control flag, avoid control coupling
+          disabled: true
+        - name: identical-switch-branches
+          disabled: true
+        - name: indent-error-flow # if block ends with a return statement, so drop this else and outdent its block # if block ends with a return statement, so drop this else and outdent its block # if block ends with a return statement, so drop this else and outdent its block # if block ends with a return statement, so drop this else and outdent its block
+          disabled: true
+        - name: line-length-limit
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: receiver-naming # receiver name should be consistent across methods
+          disabled: true
+        - name: redefines-builtin-id # redefinition of the built-in function
+          disabled: true
+        - name: unchecked-type-assertion
+          disabled: true
+        - name: unhandled-error
+          disabled: true
+        - name: unnecessary-format # unnecessary use of formatting function "fmt.Errorf", you can replace with errors.New
+          disabled: true
+        - name: unused-parameter # parameter seems to be unused, consider removeing or renaming it as _
+          disabled: true
+        - name: unused-receiver # method receiver is not referenced in method's body, consider removing or renaming as _
+          disabled: true
+        - name: use-any # 'interface{}' can be replaced by any
+          disabled: true
+        - name: use-errors-new # replace fmt.Errorf by errors.New
+          disabled: true
+        - name: var-declaration # omit type or default value in a variable delcaration
+          disabled: true
+    staticcheck:
+      checks:
+        - all # enable all before turning off selected
+        # disable some checks
+        - -ST1005 # errors strings should not be capitalized
+        - -ST1020 # comment on exported method FuncName should be of form FuncName ...
+        - -ST1021 # comment on exported type Foo should be of form Foo ...
+        - -ST1022 # comment on exported var Foo should be of form Foo ...
+        - -ST1016 # methods on the same type should have same receiver name
+        - -ST1023 # should omit type from declartion, it will be inferred from right hand side
+        - -QF1011 # could omit type from declaration, it will be inferred from right hand side
+  exclusions:
+    generated: strict
+    rules:
+      - linters:
+          # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
+          - goconst
+          - prealloc
+        path: (_test.*\.go)
+      - linters:
+          - govet
+        path: (_test.*\.go)
+        text: fieldalignment # detect Go structs that would take less memory if their fields were sorted
 
-# Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
-# without names. If there is a memory issue on a specific field, that is best found with a heap profile.
-#linters-settings:
-#  govet:
-#    enable:
-#      - fieldalignment # detect Go structs that would take less memory if their fields were sorted
-
-# Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
-issues:
-  exclude-rules:
-    - path: (_test\.go|utilities_testing\.go)
-      linters:
-        - goconst
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: strict

--- a/bucket.go
+++ b/bucket.go
@@ -6,6 +6,7 @@
 //  software will be governed by the Apache License, Version 2.0, included in
 //  the file licenses/APL2.txt.
 
+// Package sgbucket defines common interfaces to be used for interacting with buckets in Couchbase Server.
 package sgbucket
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/couchbase/sg-bucket
 
-go 1.19
+go 1.24.0
 
 require (
 	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
-	github.com/stretchr/testify v1.9.0
-	golang.org/x/text v0.17.0
+	github.com/stretchr/testify v1.11.1
+	golang.org/x/text v0.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,10 @@ github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f h1:a7clxaGmmqtdN
 github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f/go.mod h1:/mK7FZ3mFYEn9zvNPhpngTyatyehSwte5bJZ4ehL5Xw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
-golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
+golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=


### PR DESCRIPTION
- Upgrade golangci-lint to 2.0 to allow working in an editor. Skipped all failures.
- Upgraded ci action versions
- Upgraded testify and golang/x/text packages