### PR TITLE
Add RangeScanStore interface for KV range scans

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -40,6 +40,7 @@ const (
 	BucketStoreFeatureMobileXDCR
 	BucketStoreFeatureMultiXattrSubdocOperations
 	BucketStoreFeatureN1qlIfNotExistsDDL
+	BucketStoreFeatureRangeScan
 )
 
 // BucketStore is a basic interface that describes a bucket - with one or many underlying DataStore.

--- a/rangescan.go
+++ b/rangescan.go
@@ -1,0 +1,66 @@
+//  Copyright 2025-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package sgbucket
+
+// ScanTerm represents a boundary term for a range scan.
+type ScanTerm struct {
+	Term      string
+	Exclusive bool
+}
+
+// ScanType is implemented by RangeScan and SamplingScan.
+type ScanType interface {
+	isScanType()
+}
+
+// RangeScan scans documents whose keys fall within a given range.
+type RangeScan struct {
+	From *ScanTerm
+	To   *ScanTerm
+}
+
+func (RangeScan) isScanType() {}
+
+// ScanOptions configures a Scan operation.
+type ScanOptions struct {
+	IDsOnly bool // When true, only document IDs (no bodies) are returned.
+}
+
+// ScanResultItem represents a single document returned by a Scan.
+type ScanResultItem struct {
+	ID     string
+	Body   []byte // nil when IDsOnly is true
+	Cas    uint64
+	IDOnly bool
+}
+
+// ScanResultIterator iterates over the results of a Scan operation.
+type ScanResultIterator interface {
+	// Next returns the next item, or nil when iteration is complete.
+	Next() *ScanResultItem
+	// Close releases any resources held by the iterator.
+	Close() error
+}
+
+// RangeScanStore is a data store that supports KV range scan operations.
+type RangeScanStore interface {
+	Scan(scanType ScanType, opts ScanOptions) (ScanResultIterator, error)
+}
+
+// NewRangeScanForPrefix creates a RangeScan that matches all keys with the given prefix.
+func NewRangeScanForPrefix(prefix string) RangeScan {
+	return RangeScan{
+		From: &ScanTerm{
+			Term: prefix,
+		},
+		To: &ScanTerm{
+			Term: prefix + "\xf48fbfbf",
+		},
+	}
+}

--- a/rangescan.go
+++ b/rangescan.go
@@ -8,7 +8,10 @@
 
 package sgbucket
 
-import "context"
+import (
+	"context"
+	"unicode/utf8"
+)
 
 // ScanTerm represents a boundary term for a range scan.
 type ScanTerm struct {
@@ -63,7 +66,7 @@ func NewRangeScanForPrefix(prefix string) RangeScan {
 			Term: prefix,
 		},
 		To: &ScanTerm{
-			Term: prefix + "\xf48fbfbf",
+			Term: prefix + string(utf8.MaxRune),
 		},
 	}
 }

--- a/rangescan.go
+++ b/rangescan.go
@@ -8,13 +8,15 @@
 
 package sgbucket
 
+import "context"
+
 // ScanTerm represents a boundary term for a range scan.
 type ScanTerm struct {
 	Term      string
 	Exclusive bool
 }
 
-// ScanType is implemented by RangeScan and SamplingScan.
+// ScanType is implemented by range scan types such as RangeScan.
 type ScanType interface {
 	isScanType()
 }
@@ -33,24 +35,25 @@ type ScanOptions struct {
 }
 
 // ScanResultItem represents a single document returned by a Scan.
+// Body is nil when ScanOptions.IDsOnly is true.
 type ScanResultItem struct {
-	ID     string
-	Body   []byte // nil when IDsOnly is true
-	Cas    uint64
-	IDOnly bool
+	ID   string
+	Body []byte
+	Cas  uint64
 }
 
 // ScanResultIterator iterates over the results of a Scan operation.
+// Next returns nil at end-of-stream or on error; call Close to retrieve any error.
 type ScanResultIterator interface {
-	// Next returns the next item, or nil when iteration is complete.
-	Next() *ScanResultItem
-	// Close releases any resources held by the iterator.
-	Close() error
+	// Next returns the next item, or nil when iteration is complete or an error has occurred.
+	Next(ctx context.Context) *ScanResultItem
+	// Close releases any resources held by the iterator and returns any errors seen during iteration.
+	Close(ctx context.Context) error
 }
 
 // RangeScanStore is a data store that supports KV range scan operations.
 type RangeScanStore interface {
-	Scan(scanType ScanType, opts ScanOptions) (ScanResultIterator, error)
+	Scan(ctx context.Context, scanType ScanType, opts ScanOptions) (ScanResultIterator, error)
 }
 
 // NewRangeScanForPrefix creates a RangeScan that matches all keys with the given prefix.


### PR DESCRIPTION
Adds a new `sgbucket.RangeScanStore` interface that exposes KV range scan operations through the bucket abstraction layer.
This mirrors the gocb Collection.Scan() API in a simplified form.

  - `RangeScanStore` interface with `Scan()` method
  - `RangeScan` scan type with `ScanTerm` boundaries (inclusive/exclusive)
  - `ScanResultIterator` for streaming results with `Next()`/`Close()`
  - `ScanOptions` with `IDsOnly` support for key-only scans
  - `NewRangeScanForPrefix()` helper for common prefix-based scans (iterate through all docs starting with prefix)
  - `BucketStoreFeatureRangeScan`