### PR TITLE
CBG-4640: Replace KeysOnly with FeedContent flag to control values for body and xattrs

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -130,6 +130,7 @@ type Xattr struct {
 	Value []byte
 }
 
+// Xattrs converts a map of xattr name/value pairs into a slice of Xattr structs.
 func Xattrs(xattrs map[string][]byte) []Xattr {
 	xattrList := make([]Xattr, 0, len(xattrs))
 	for name, value := range xattrs {


### PR DESCRIPTION
Prereq for CBG-4640 in Sync Gateway (and Rosmar)