### PR TITLE
CBG-5175 allow GetMaxVbNo on DataStore

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -69,7 +69,7 @@ type DynamicDataStoreBucket interface {
 
 // MutationFeedStore is a DataStore that supports a DCP or TAP streaming mutation feed.
 type MutationFeedStore interface {
-	// GetMaxVbno returns the number of vBuckets of this store; usually 1024.
+	// GetMaxVbno returns the number of vBuckets of this store.
 	GetMaxVbno() (uint16, error)
 
 	// StartDCPFeed starts a new DCP event feed. Events will be passed to the callback function.
@@ -92,6 +92,9 @@ type DataStore interface {
 	// An integer that uniquely identifies this Collection in its Bucket.
 	// The default collection always has the ID zero.
 	GetCollectionID() uint32
+
+	// GetMaxVbno returns the number of vBuckets of this store.
+	GetMaxVbno() (uint16, error)
 
 	KVStore
 	XattrStore


### PR DESCRIPTION
CBG-5175 allow GetMaxVbNo on DataStore

I'd like to add `GetMaxVbNo` to `DataStore` so that we do not have to pass a Bucket and a DataStore if we need both values, since the vBuckets can be relevant to `DataStore`.