### PR TITLE
CBG-5460 move hlc implementation to sg-bucket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/couchbase/sg-bucket
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/hlc.go
+++ b/hlc.go
@@ -36,7 +36,7 @@ type HybridLogicalClock struct {
 
 // NewHybridLogicalClock returns a HybridLogicalClock backed by the system wall clock.
 func NewHybridLogicalClock() *HybridLogicalClock {
-	return &HybridLogicalClock{clock: func() uint64 { return hlcWallClock() }}
+	return &HybridLogicalClock{clock: hlcWallClock}
 }
 
 // HLCWallClock returns the current wall-clock time in nanoseconds since the Unix epoch, using the same

--- a/hlc.go
+++ b/hlc.go
@@ -1,0 +1,99 @@
+//  Copyright 2026-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package sgbucket
+
+import "sync"
+
+// HLCLogicalBits is the number of low-order bits of a Couchbase Server CAS reserved for the logical
+// (counter) component of the Hybrid Logical Clock. The remaining high-order bits hold the physical
+// (wall-clock nanosecond) component. Clearing these bits when reading the wall clock keeps generated
+// values in the same numeric space as a CAS and leaves room for same-instant logical increments.
+const HLCLogicalBits = 16
+
+// HLCLogicalMask masks off the logical component, isolating the physical component of a timestamp.
+const HLCLogicalMask uint64 = (1 << HLCLogicalBits) - 1
+
+// HybridLogicalClock generates monotonically increasing timestamps in the same numeric space as a
+// Couchbase Server CAS (a 48-bit nanosecond physical component plus a 16-bit logical counter). Sync
+// Gateway uses it to assign HLV current-version values without relying on server-side CAS macro
+// expansion, so the value is known before the write and can be written as a literal into every xattr
+// field that would otherwise require a per-field subdoc macro-expansion path.
+//
+// Generated values are CAS-comparable: under synchronised clocks a value generated just before a write
+// is below the CAS the server stamps at commit. Monotonicity per HLV source is the caller's
+// responsibility, supplied via the floor argument to Now.
+type HybridLogicalClock struct {
+	clock       func() uint64 // wall-clock source, nanoseconds since the Unix epoch; overridable in tests
+	highestTime uint64
+	mutex       sync.Mutex
+}
+
+// NewHybridLogicalClock returns a HybridLogicalClock backed by the system wall clock.
+func NewHybridLogicalClock() *HybridLogicalClock {
+	return &HybridLogicalClock{clock: func() uint64 { return hlcWallClock() }}
+}
+
+// HLCWallClock returns the current wall-clock time in nanoseconds since the Unix epoch, using the same
+// high-resolution platform source the HLC is backed by (GetSystemTimePreciseAsFileTime on Windows,
+// time.Now() for other OS). Tests that simulate clock skew should derive their injected clock from this so
+// they share a time base with the bucket's clock.
+func HLCWallClock() uint64 {
+	return hlcWallClock()
+}
+
+// SetClockForTest overrides the wall-clock source and resets the clock's high-water mark, so the next
+// value returned by Now is determined solely by getTime. Test-only: used to simulate clock skew between
+// Sync Gateway and the server.
+func (c *HybridLogicalClock) SetClockForTest(getTime func() uint64) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.clock = getTime
+	c.highestTime = 0
+}
+
+// UpdateFloor updates the clock's high-water mark to floor if floor exceeds the current value,
+// without generating a new timestamp. Use this to sync the HLC with externally-observed timestamps
+// (e.g. CAS values read from storage) so subsequent Now calls are guaranteed to exceed them.
+func (c *HybridLogicalClock) UpdateFloor(floor uint64) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if floor > c.highestTime {
+		c.highestTime = floor
+	}
+}
+
+// Now returns the next timestamp, guaranteed to be strictly greater than both the previous value
+// returned by this clock (monotonic across calls) and the supplied floor, while tracking the wall clock
+// where possible. The result is max(physical, highestTime+1, floor+1) where physical is the wall-clock
+// time with its logical bits cleared.
+//
+// floor is the highest existing HLV version value for the caller's source; passing 0 (a brand-new
+// document, or a source not yet present in the HLV) imposes no lower bound beyond monotonicity, so Now(0)
+// is an ordinary clock tick.
+func (c *HybridLogicalClock) Now(floor uint64) uint64 {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	next := c.clock() &^ HLCLogicalMask // physical component, tracks the wall clock
+	if c.highestTime+1 > next {         // ensure strictly greater than the previous value
+		next = c.highestTime + 1
+	}
+	if floor+1 > next { // ensure strictly greater than the caller's floor
+		next = floor + 1
+	}
+	c.highestTime = next
+	return next
+}
+
+// CASToPhysicalNanos returns the physical (wall-clock nanosecond) component of a CAS / HLC value, with the
+// logical counter bits cleared. The difference between two such values approximates the elapsed wall-clock
+// time between them, which is used to decide how long to wait for a lagging clock to catch up.
+func CASToPhysicalNanos(cas uint64) uint64 {
+	return cas &^ HLCLogicalMask
+}

--- a/hlc_nonwindows.go
+++ b/hlc_nonwindows.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+//  Copyright 2026-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package sgbucket
+
+import "time"
+
+func hlcWallClock() uint64 {
+	return uint64(time.Now().UnixNano())
+}

--- a/hlc_test.go
+++ b/hlc_test.go
@@ -1,0 +1,182 @@
+//  Copyright 2026-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package sgbucket
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hourNanos is an offset used to place test floors a wall-clock hour either side of "now".
+const hourNanos = uint64(time.Hour)
+
+// TestHybridLogicalClockMonotonic asserts successive values from the system-backed clock strictly increase.
+func TestHybridLogicalClockMonotonic(t *testing.T) {
+	hlc := NewHybridLogicalClock()
+	prev := hlc.Now(0)
+	for i := 0; i < 1000; i++ {
+		next := hlc.Now(0)
+		require.Greater(t, next, prev, "value at iteration %d did not strictly increase", i)
+		prev = next
+	}
+}
+
+// TestHybridLogicalClockTracksWallClock asserts Now(0) reflects the wall clock (physical component) with
+// its logical bits cleared, rather than drifting off into logical-counter space from a cold start.
+func TestHybridLogicalClockTracksWallClock(t *testing.T) {
+	hlc := NewHybridLogicalClock()
+	before := hlcWallClock() &^ HLCLogicalMask
+	got := hlc.Now(0)
+	after := hlcWallClock()
+	require.GreaterOrEqual(t, got, before)
+	require.LessOrEqual(t, got, after)
+}
+
+// TestHybridLogicalClockSameInstant asserts that when the wall clock does not advance, successive values
+// still strictly increase via the logical counter.
+func TestHybridLogicalClockSameInstant(t *testing.T) {
+	now := uint64(time.Now().UnixNano())
+	hlc := &HybridLogicalClock{clock: func() uint64 { return now }}
+
+	first := hlc.Now(0)
+	require.Equal(t, now&^HLCLogicalMask, first)
+	require.Equal(t, first+1, hlc.Now(0))
+	require.Equal(t, first+2, hlc.Now(0))
+}
+
+// TestHybridLogicalClockPhysicalMask asserts the logical bits of the wall clock are cleared so generated
+// values stay in the CAS numeric space.
+func TestHybridLogicalClockPhysicalMask(t *testing.T) {
+	// OR in low bits so masking is observable regardless of the current nanosecond.
+	now := uint64(time.Now().UnixNano()) | HLCLogicalMask
+	hlc := &HybridLogicalClock{clock: func() uint64 { return now }}
+
+	got := hlc.Now(0)
+	// Isolates only bits 15–0 of the result. Requires them to be all zero — proving Now() stripped them via &^ HLCLogicalMask.
+	require.Zero(t, got&HLCLogicalMask, "low %d (logical) bits should be cleared", HLCLogicalBits)
+	// Both sides clear the low 16 bits of now
+	require.Equal(t, now&^HLCLogicalMask, got)
+}
+
+// TestHybridLogicalClockFloor asserts Now never returns a value <= floor.
+func TestHybridLogicalClockFloor(t *testing.T) {
+	t.Run("floor below physical is ignored", func(t *testing.T) {
+		now := uint64(time.Now().UnixNano())
+		hlc := &HybridLogicalClock{clock: func() uint64 { return now }}
+		got := hlc.Now(now - hourNanos) // a floor an hour in the past
+		require.Equal(t, now&^HLCLogicalMask, got)
+	})
+
+	t.Run("floor above physical wins", func(t *testing.T) {
+		now := uint64(time.Now().UnixNano())
+		hlc := &HybridLogicalClock{clock: func() uint64 { return now }}
+		floor := now + hourNanos // a floor an hour in the future
+		got := hlc.Now(floor)
+		require.Equal(t, floor+1, got)
+		require.Greater(t, got, floor)
+	})
+}
+
+// TestHybridLogicalClockNoFloor covers the brand-new-document / absent-source case where floor is 0: Now
+// behaves as an ordinary tick rather than special-casing.
+func TestHybridLogicalClockNoFloor(t *testing.T) {
+	now := uint64(time.Now().UnixNano())
+	hlc := &HybridLogicalClock{clock: func() uint64 { return now }}
+	require.Equal(t, now&^HLCLogicalMask, hlc.Now(0))
+}
+
+// TestHybridLogicalClockConcurrent asserts thread-safety: concurrent callers never receive duplicate
+// values (strict monotonicity implies uniqueness).
+func TestHybridLogicalClockConcurrent(t *testing.T) {
+	hlc := NewHybridLogicalClock()
+
+	const goroutines = 16
+	const perGoroutine = 500
+
+	var wg sync.WaitGroup
+	results := make([][]uint64, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			values := make([]uint64, perGoroutine)
+			for i := range values {
+				values[i] = hlc.Now(0)
+			}
+			results[g] = values
+		}(g)
+	}
+	wg.Wait()
+
+	seen := make(map[uint64]struct{}, goroutines*perGoroutine)
+	for _, values := range results {
+		for _, v := range values {
+			_, dup := seen[v]
+			assert.False(t, dup, "duplicate value %d returned to concurrent callers", v)
+			seen[v] = struct{}{}
+		}
+	}
+	require.Len(t, seen, goroutines*perGoroutine)
+}
+
+// TestHLCReverseTime asserts that the clock remains strictly monotonic when the underlying wall clock goes
+// backwards, advancing via the logical counter until the physical clock catches up.
+func TestHLCReverseTime(t *testing.T) {
+	startTime := uint64(1_000_000) // 1000000 ns = 0xF4240; masked to 0xF0000
+	wallTime := startTime
+	h := HybridLogicalClock{clock: func() uint64 { return wallTime }}
+
+	require.Equal(t, uint64(0xf0000), h.Now(0))
+	require.Equal(t, uint64(0xf0001), h.Now(0))
+
+	// reverse time: logical counter keeps advancing
+	wallTime = 0
+	require.Equal(t, uint64(0xf0002), h.Now(0))
+
+	// back to normal: still advancing via counter until physical overtakes
+	wallTime = startTime
+	require.Equal(t, uint64(0xf0003), h.Now(0))
+
+	// reverse again
+	wallTime = 1
+	require.Equal(t, uint64(0xf0004), h.Now(0))
+
+	// jump to startTime*2 = 0x1E8480; masked to 0x1E0000 which exceeds counter
+	wallTime = startTime * 2
+	require.Equal(t, uint64(0x1e0000), h.Now(0))
+	require.Equal(t, uint64(0x1e0001), h.Now(0))
+
+	// jump to startTime*4 = 0x3D0900; masked to 0x3D0000
+	wallTime *= 2
+	require.Equal(t, uint64(0x3d0000), h.Now(0))
+}
+
+// TestHybridLogicalClockUpdateFloor asserts UpdateFloor adjusts the high-water mark without advancing the
+// clock, so subsequent Now calls are strictly above the supplied floor.
+func TestHybridLogicalClockUpdateFloor(t *testing.T) {
+	now := uint64(time.Now().UnixNano())
+	h := &HybridLogicalClock{clock: func() uint64 { return now }}
+
+	// UpdateFloor below current highestTime is a no-op
+	h.UpdateFloor(0)
+	require.Equal(t, uint64(0), h.highestTime)
+
+	// UpdateFloor sets highestTime when higher
+	floor := now + hourNanos
+	h.UpdateFloor(floor)
+	require.Equal(t, floor, h.highestTime)
+
+	// Subsequent Now must be strictly above the floor
+	got := h.Now(0)
+	require.Greater(t, got, floor)
+}

--- a/hlc_test.go
+++ b/hlc_test.go
@@ -105,16 +105,14 @@ func TestHybridLogicalClockConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	results := make([][]uint64, goroutines)
-	for g := 0; g < goroutines; g++ {
-		wg.Add(1)
-		go func(g int) {
-			defer wg.Done()
+	for g := range goroutines {
+		wg.Go(func() {
 			values := make([]uint64, perGoroutine)
 			for i := range values {
 				values[i] = hlc.Now(0)
 			}
 			results[g] = values
-		}(g)
+		})
 	}
 	wg.Wait()
 

--- a/hlc_windows.go
+++ b/hlc_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+//  Copyright 2026-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package sgbucket
+
+import "golang.org/x/sys/windows"
+
+// hlcWallClock returns the current wall-clock time in nanoseconds since the Unix epoch. On Windows,
+// time.Now() is backed by the coarse system timer (~0.5-15ms resolution), which is too low for the HLC:
+// successive writes land in the same physical slot, forcing logical increments and diverging from the CAS.
+// GetSystemTimePreciseAsFileTime reads the high-resolution system clock (~100ns) directly, so it is read
+// live on every call rather than anchored once. Reading live (rather than anchoring an offset against
+// QueryPerformanceCounter) keeps this in lockstep with any other clock in the same process that reads the
+// same system time, avoiding a fixed startup skew between the HLC and the bucket's clock.
+func hlcWallClock() uint64 {
+	var ft windows.Filetime
+	windows.GetSystemTimePreciseAsFileTime(&ft)
+	return uint64(ft.Nanoseconds())
+}


### PR DESCRIPTION
This review was already done in an earlier stage of https://github.com/couchbase/sync_gateway/pull/8375 - this just collapses the code into the sg-bucket repo from the sync_gateway and rosmar repos. This moves hlc files into sg-bucket from sync_gateway as they were done in the upstream sync gateway PR.

Blocks https://github.com/couchbaselabs/rosmar/pull/79 and https://github.com/couchbase/sync_gateway/pull/8375