### PR TITLE
Update CI values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,21 @@ on:
       - 'main'
       - 'release/*'
 
+env:
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@v6
+  ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@v6
+  GO_VERSION: &go_version 1.26.4
+  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.9.0
+
 jobs:
   addlicense:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
-          go-version: 1.24.10
+          go-version: *go_version
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -40,10 +46,10 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
-          go-version: 1.24.10
+          go-version: *go_version
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -51,7 +57,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *go_test_annotations_version
         with:
           test-results: test.json
 
@@ -59,14 +65,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
-          go-version: 1.24.10
+          go-version: *go_version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.2
+          version: v2.12.2
 
   test-race:
     runs-on: ${{ matrix.os }}
@@ -75,15 +81,15 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
-          go-version: 1.24.10
+          go-version: *go_version
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *go_test_annotations_version
         with:
           test-results: test.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+repos:
+  - repo: local
+    hooks:
+      - id: addlicense
+        name: addlicense
+        language: system
+        entry: go run github.com/google/addlicense@latest -f licenses/addlicense.tmpl
+        types_or: [go, python]
+
+      - id: goimports
+        name: goimports
+        language: system
+        entry: go run golang.org/x/tools/cmd/goimports@latest
+        args: [-w]
+        types: [go]
+
+      - id: golangci-lint
+        name: golangci-lint
+        language: system
+        # version must match .github/workflows/ci.yml golangci job
+        entry: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+        args: [run, --config=.golangci-strict.yml, --fix=false]
+        types: [go]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,6 @@ repos:
         language: system
         # version must match .github/workflows/ci.yml golangci job
         entry: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
-        args: [run, --config=.golangci-strict.yml, --fix=false]
+        args: [run, --config=.golangci.yml, --fix=false]
         types: [go]
         pass_filenames: false

--- a/views.go
+++ b/views.go
@@ -451,7 +451,9 @@ func (result *ViewResult) makeCollationKeys() {
 
 func (result *ViewResult) Sort() {
 	result.makeCollationKeys()
-	sort.Sort(result)
+	// sort.Sort is used instead of slices.SortFunc to avoid allocating a temporary paired slice
+	// to keep Rows and collationKeys in sync; sort.Interface methods operate on both in-place.
+	sort.Sort(result) //nolint:revive
 }
 
 func (result *ViewResult) Len() int {


### PR DESCRIPTION
prep for picking up go 1.25 in an upcoming commit

prereq for https://github.com/couchbase/sg-bucket/pull/146

add pre-commit support (see https://github.com/couchbase/sync_gateway/pull/8379). Use of this is optional.